### PR TITLE
Fix asm compiler detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.4.3)
 
-project(ccache LANGUAGES ASM C CXX)
+project(ccache LANGUAGES C CXX ASM)
 set(CMAKE_PROJECT_DESCRIPTION "a fast C/C++ compiler cache")
 
 set(CMAKE_CXX_STANDARD 11)

--- a/src/ResultDumper.hpp
+++ b/src/ResultDumper.hpp
@@ -28,13 +28,13 @@ class ResultDumper : public Result::Reader::Consumer
 public:
   ResultDumper(FILE* stream);
 
-  void on_header(CacheEntryReader& cache_entry_reader) final;
+  void on_header(CacheEntryReader& cache_entry_reader) override;
   void on_entry_start(uint32_t entry_number,
                               Result::FileType file_type,
                               uint64_t file_len,
-                              nonstd::optional<std::string> raw_file) final;
-  void on_entry_data(const uint8_t* data, size_t size) final;
-  void on_entry_end() final;
+                              nonstd::optional<std::string> raw_file) override;
+  void on_entry_data(const uint8_t* data, size_t size) override;
+  void on_entry_end() override;
 
 private:
   FILE* m_stream;

--- a/src/ResultDumper.hpp
+++ b/src/ResultDumper.hpp
@@ -28,13 +28,13 @@ class ResultDumper : public Result::Reader::Consumer
 public:
   ResultDumper(FILE* stream);
 
-  virtual void on_header(CacheEntryReader& cache_entry_reader);
-  virtual void on_entry_start(uint32_t entry_number,
+  void on_header(CacheEntryReader& cache_entry_reader) final;
+  void on_entry_start(uint32_t entry_number,
                               Result::FileType file_type,
                               uint64_t file_len,
-                              nonstd::optional<std::string> raw_file);
-  virtual void on_entry_data(const uint8_t* data, size_t size);
-  virtual void on_entry_end();
+                              nonstd::optional<std::string> raw_file) final;
+  void on_entry_data(const uint8_t* data, size_t size) final;
+  void on_entry_end() final;
 
 private:
   FILE* m_stream;

--- a/src/ResultExtractor.hpp
+++ b/src/ResultExtractor.hpp
@@ -31,13 +31,13 @@ class ResultExtractor : public Result::Reader::Consumer
 public:
   ResultExtractor(const std::string& directory);
 
-  virtual void on_header(CacheEntryReader& cache_entry_reader);
-  virtual void on_entry_start(uint32_t entry_number,
+  void on_header(CacheEntryReader& cache_entry_reader) final;
+  void on_entry_start(uint32_t entry_number,
                               Result::FileType file_type,
                               uint64_t file_len,
-                              nonstd::optional<std::string> raw_file);
-  virtual void on_entry_data(const uint8_t* data, size_t size);
-  virtual void on_entry_end();
+                              nonstd::optional<std::string> raw_file) final;
+  void on_entry_data(const uint8_t* data, size_t size) final;
+  void on_entry_end() final;
 
 private:
   const std::string m_directory;

--- a/src/ResultExtractor.hpp
+++ b/src/ResultExtractor.hpp
@@ -31,13 +31,13 @@ class ResultExtractor : public Result::Reader::Consumer
 public:
   ResultExtractor(const std::string& directory);
 
-  void on_header(CacheEntryReader& cache_entry_reader) final;
+  void on_header(CacheEntryReader& cache_entry_reader) override;
   void on_entry_start(uint32_t entry_number,
                               Result::FileType file_type,
                               uint64_t file_len,
-                              nonstd::optional<std::string> raw_file) final;
-  void on_entry_data(const uint8_t* data, size_t size) final;
-  void on_entry_end() final;
+                              nonstd::optional<std::string> raw_file) override;
+  void on_entry_data(const uint8_t* data, size_t size) override;
+  void on_entry_end() override;
 
 private:
   const std::string m_directory;

--- a/src/ResultRetriever.hpp
+++ b/src/ResultRetriever.hpp
@@ -31,13 +31,13 @@ class ResultRetriever : public Result::Reader::Consumer
 public:
   ResultRetriever(Context& ctx, bool rewrite_dependency_target);
 
-  virtual void on_header(CacheEntryReader& cache_entry_reader);
-  virtual void on_entry_start(uint32_t entry_number,
+  void on_header(CacheEntryReader& cache_entry_reader) final;
+  void on_entry_start(uint32_t entry_number,
                               Result::FileType file_type,
                               uint64_t file_len,
-                              nonstd::optional<std::string> raw_file);
-  virtual void on_entry_data(const uint8_t* data, size_t size);
-  virtual void on_entry_end();
+                              nonstd::optional<std::string> raw_file) final;
+  void on_entry_data(const uint8_t* data, size_t size) final;
+  void on_entry_end() final;
 
 private:
   Context& m_ctx;

--- a/src/ResultRetriever.hpp
+++ b/src/ResultRetriever.hpp
@@ -31,13 +31,13 @@ class ResultRetriever : public Result::Reader::Consumer
 public:
   ResultRetriever(Context& ctx, bool rewrite_dependency_target);
 
-  void on_header(CacheEntryReader& cache_entry_reader) final;
+  void on_header(CacheEntryReader& cache_entry_reader) override;
   void on_entry_start(uint32_t entry_number,
                               Result::FileType file_type,
                               uint64_t file_len,
-                              nonstd::optional<std::string> raw_file) final;
-  void on_entry_data(const uint8_t* data, size_t size) final;
-  void on_entry_end() final;
+                              nonstd::optional<std::string> raw_file) override;
+  void on_entry_data(const uint8_t* data, size_t size) override;
+  void on_entry_end() override;
 
 private:
   Context& m_ctx;

--- a/src/third_party/fmt/core.h
+++ b/src/third_party/fmt/core.h
@@ -99,7 +99,7 @@
 #endif
 
 #ifndef FMT_OVERRIDE
-#  if FMT_HAS_FEATURE(cxx_override) || \
+#  if FMT_HAS_FEATURE(cxx_override_control) || \
       (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) || FMT_MSC_VER >= 1900
 #    define FMT_OVERRIDE override
 #  else


### PR DESCRIPTION
I stumbled upon this due to a new setup.
Turns out CMake requires ASM to be the last parameter so it can try whether the C compiler can compile asm.
See https://gitlab.kitware.com/cmake/cmake/-/merge_requests/1560/diffs


### How to reproduce ###
This might be not 100% accurate, it's from memory:
1. Install Ubuntu 18.04
2. `sudo apt update`
3. `sudo apt upgrade`
4. `sudo apt install clang-10`
5. `sudo ln -s /usr/local/bin/c++ /usr/bin/clang++-10`
6. `sudo ln -s /usr/local/bin/cc /usr/bin/clang-10`

And out of desperation:
7. `sudo apt install build-essential`

### Actual behavior ###
```
-- The ASM compiler identification is unknown
-- Found assembler: /usr/local/bin/cc
-- The C compiler identification is Clang 10.0.0
-- The CXX compiler identification is Clang 10.0.0
-- Warning: Did not find file Compiler/-ASM
-- Check for working C compiler: /usr/local/bin/cc
-- Check for working C compiler: /usr/local/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/local/bin/c++
-- Check for working CXX compiler: /usr/local/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
```


A little later blake3 fails since it doesn't expect to have to ASM compiler.
We could fix blake3 to use C code in case there is no ASM compiler.
But I guess we do want the ASM version since they specifically offer it.